### PR TITLE
Update to @rdfjs/data-model

### DIFF
--- a/lib/ParserStream.js
+++ b/lib/ParserStream.js
@@ -1,6 +1,6 @@
 const concat = require('concat-stream')
 const jsonld = require('jsonld')
-const rdf = require('rdf-data-model')
+const rdf = require('@rdfjs/data-model')
 const Readable = require('readable-stream')
 
 class ParserStream extends Readable {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   },
   "homepage": "https://github.com/rdf-ext/rdf-parser-jsonld",
   "dependencies": {
+    "@rdfjs/data-model": "^1.1.0",
     "concat-stream": "^1.5.1",
     "jsonld": "^0.4.11",
-    "rdf-data-model": "^1.0.0",
     "rdf-sink": "^1.0.0",
     "readable-stream": "^2.2.9"
   },


### PR DESCRIPTION
This moves from `rdf-data-model` to `@rdfjs/data-model`.